### PR TITLE
feat: add newpp-report userscript and generalize Commons deploy

### DIFF
--- a/.github/workflows/update-commons.yml
+++ b/.github/workflows/update-commons.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'new-category.js'
+      - 'newpp-report.js'
 
 permissions:
   contents: read
@@ -16,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -23,10 +26,20 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Update Commons page
+      - name: Deploy new-category.js
+        if: ${{ contains(github.event.commits[0].modified, 'new-category.js') || contains(github.event.commits[0].added, 'new-category.js') }}
         env:
           MW_CONSUMER_TOKEN: ${{ secrets.MW_CONSUMER_TOKEN }}
           MW_CONSUMER_SECRET: ${{ secrets.MW_CONSUMER_SECRET }}
           MW_ACCESS_TOKEN: ${{ secrets.MW_ACCESS_TOKEN }}
           MW_ACCESS_SECRET: ${{ secrets.MW_ACCESS_SECRET }}
-        run: bun scripts/update-commons.ts
+        run: bun scripts/update-commons.ts new-category.js User:DaxServer/new-category.js
+
+      - name: Deploy newpp-report.js
+        if: ${{ contains(github.event.commits[0].modified, 'newpp-report.js') || contains(github.event.commits[0].added, 'newpp-report.js') }}
+        env:
+          MW_CONSUMER_TOKEN: ${{ secrets.MW_CONSUMER_TOKEN }}
+          MW_CONSUMER_SECRET: ${{ secrets.MW_CONSUMER_SECRET }}
+          MW_ACCESS_TOKEN: ${{ secrets.MW_ACCESS_TOKEN }}
+          MW_ACCESS_SECRET: ${{ secrets.MW_ACCESS_SECRET }}
+        run: bun scripts/update-commons.ts newpp-report.js User:DaxServer/newpp-report.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,10 @@ mw.hook('ve.saveDialog.stateChanged').add(() => {
 - `thehindu.js` - Node.js script for scraping news articles (uses Cheerio, got, moment)
 - `cbfc.js` - Puppeteer script for scraping film certification data
 
+## Deploying Scripts to Commons
+
+`bun scripts/update-commons.ts <local-file> <wiki-page-title>` — deploys a local JS file to a Commons user page via OAuth. The GitHub Actions workflow (`.github/workflows/update-commons.yml`) runs this automatically on push to `main` when tracked files change. Add new files to the `paths` trigger and a corresponding deploy step.
+
 ## Testing
 
 Cypress is available for end-to-end testing. Test configuration is in `cypress.json` (currently empty). Run tests with:
@@ -185,9 +189,32 @@ Key npm packages:
 - `moment` - Date/time manipulation
 - `prompts` - Interactive CLI prompts
 
+## Lua Module Development
+
+### Fetching Commons/MediaWiki docs
+
+- `bun scripts/fetch-mediawiki-doc.ts <url> [search-term]` — fetch via markdown.new (cleaner than raw HTML)
+- `bun scripts/fetch-mediawiki-doc.ts --raw https://commons.wikimedia.org "Module:Name" [search-term]` — fetch raw Lua source via MediaWiki API
+
+### Template performance
+
+- `#ifexist` is an expensive parser function (database hit per call, 100-call limit per page). Prefer Lua data tables over `#ifexist` chains in templates.
+
+### Module patterns
+
+- `mw.loadData` for pure data tables (i18n, lookups); `require` for modules with functions
+- Many Commons modules export `_functionName` APIs for Lua-to-Lua calls (no frame needed):
+  - `Module:List` → `List.makeList('horizontal', items)`
+  - `Module:ISOdate` → `ISOdate._ISOdate(dateStr, lang)`
+  - `Module:City` → `City._city(place, lang, link)`
+  - `Module:Countries` → `Countries._main(options, require('Module:Countries/' .. continent))`
+    - options: `{prefix, suffix, presep, sufsep, lang, nocat}`
+- `mw.language.getFallbacksFor(lang)` for proper i18n fallback chains (not just direct `bucket['en']`)
+- `mw.ustring.gsub` not `string.gsub` for Unicode-safe substitutions
+
 ## Code Conventions
 
-- All userscripts start with `// <nowiki>` comment wrapper
+- All userscripts wrap content with `// <nowiki>` at top and `// </nowiki>` at bottom
 - Use ES6+ features (arrow functions, const/let, template literals)
 - Use strict equality (`===`, `!==`)
 - Indent with tabs (existing code convention)

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "vue": "^3.5.33",
       },
       "devDependencies": {
+        "@tsconfig/bun": "^1.0.10",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.3",
       },
@@ -45,6 +46,8 @@
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@8.0.0", "", {}, "sha512-YvOsokBE5NsyHuXMnwEVB7lgFk6lX8F4OXCruYVgFII0hUHof0RGUvhMoabVt9hRqbg+qVzayzEG24RCcxcYeA=="],
+
+    "@tsconfig/bun": ["@tsconfig/bun@1.0.10", "", {}, "sha512-5AV5YknQjNyoYzZ/8NG0dawqew/wH+x7ANiCfCIn29qo0cdbd1EryvFD1k5NSZWLBMOI/fGqMIaxi58GPIP9Cg=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 

--- a/newpp-report.js
+++ b/newpp-report.js
@@ -1,0 +1,72 @@
+// <nowiki>
+
+$.when(
+	$.ready,
+	mw.loader.using( 'mediawiki.util' )
+).then(function () {
+	const report = mw.config.get( 'wgPageParseReport' );
+	if ( !report ) {
+		return;
+	}
+
+	const { limitreport, scribunto, cachereport } = report;
+
+	function formatBytes( n ) {
+		if ( n >= 1048576 ) return ( n / 1048576 ).toFixed( 2 ) + ' MB';
+		if ( n >= 1024 ) return ( n / 1024 ).toFixed( 1 ) + ' KB';
+		return n + ' B';
+	}
+
+	function overLimit( value, limit ) {
+		return limit !== undefined && value > limit;
+	}
+
+	function metricRow( label, value, limit, format ) {
+		const fmt = format || String;
+		const fVal = fmt( value );
+		const fLim = limit !== undefined ? fmt( limit ) : null;
+		const over = overLimit( value, limit );
+		const style = over ? 'color:#d33;font-weight:bold;' : '';
+		const limitCell = fLim !== null ? `<td style="padding:1px 8px;${style}">${fVal} / ${fLim}</td>` : `<td style="padding:1px 8px;">${fVal}</td>`;
+		return `<tr><td style="padding:1px 8px;color:#54595d;">${label}</td>${limitCell}${over ? '<td style="color:#d33;">⚠ over limit</td>' : '<td></td>'}</tr>`;
+	}
+
+	const rows = [
+		metricRow( 'CPU time', limitreport.cputime + ' s' ),
+		metricRow( 'Wall time', limitreport.walltime + ' s' ),
+		metricRow( 'Expensive function count', limitreport.expensivefunctioncount.value, limitreport.expensivefunctioncount.limit ),
+		metricRow( 'PP visited nodes', limitreport.ppvisitednodes.value, limitreport.ppvisitednodes.limit ),
+		metricRow( 'Expansion depth', limitreport.expansiondepth.value, limitreport.expansiondepth.limit ),
+		metricRow( 'Post-expand include size', limitreport.postexpandincludesize.value, limitreport.postexpandincludesize.limit, formatBytes ),
+		metricRow( 'Template argument size', limitreport.templateargumentsize.value, limitreport.templateargumentsize.limit, formatBytes ),
+		metricRow( 'Revision size', limitreport.revisionsize.value, limitreport.revisionsize.limit, formatBytes ),
+		metricRow( 'Unstrip depth', limitreport[ 'unstrip-depth' ].value, limitreport[ 'unstrip-depth' ].limit ),
+		metricRow( 'Unstrip size', limitreport[ 'unstrip-size' ].value, limitreport[ 'unstrip-size' ].limit, formatBytes ),
+		metricRow( 'Entity access count', limitreport.entityaccesscount.value, limitreport.entityaccesscount.limit ),
+	];
+
+	if ( scribunto ) {
+		rows.push( metricRow( 'Lua time', scribunto[ 'limitreport-timeusage' ].value + ' s', parseFloat( scribunto[ 'limitreport-timeusage' ].limit ) > 0 ? scribunto[ 'limitreport-timeusage' ].limit + ' s' : undefined ) );
+		rows.push( metricRow( 'Lua memory', scribunto[ 'limitreport-memusage' ].value, scribunto[ 'limitreport-memusage' ].limit, formatBytes ) );
+	}
+
+	const timingRows = ( limitreport.timingprofile || [] )
+		.map( ( line ) => `<tr><td colspan="3" style="padding:1px 8px;font-family:monospace;white-space:pre;">${mw.html.escape( line )}</td></tr>` )
+		.join( '' );
+
+	const cacheTime = cachereport && cachereport.timestamp
+		? cachereport.timestamp.replace( /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/, '$1-$2-$3 $4:$5:$6' )
+		: '';
+
+	const $box = $( `<details id="newpp-report" style="margin-top:2em;border:1px solid #a2a9b1;padding:0.5em 1em;font-size:0.85em;">
+		<summary style="cursor:pointer;font-weight:bold;">NewPP limit report${cacheTime ? ' — cached ' + cacheTime : ''}</summary>
+		<table style="border-collapse:collapse;margin-top:0.6em;">
+			${rows.join( '' )}
+			${timingRows ? '<tr><td colspan="3" style="padding-top:0.6em;font-weight:bold;">Timing profile</td></tr>' + timingRows : ''}
+		</table>
+	</details>` );
+
+	$( '#content' ).append( $box );
+} );
+
+// </nowiki>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@tsconfig/bun": "^1.0.10",
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.3"
   }

--- a/scripts/fetch-mediawiki-doc.ts
+++ b/scripts/fetch-mediawiki-doc.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+// Fetch a MediaWiki page and print cleaned content to stdout
+//
+// Modes:
+//   bun scripts/fetch-mediawiki-doc.ts <wiki-url> [search-term]
+//     Fetches via markdown.new, optionally extracts section around search-term
+//
+//   bun scripts/fetch-mediawiki-doc.ts --raw <wiki-base-url> <Module:Name> [search-term]
+//     Fetches raw wikitext via MediaWiki API (good for Lua module source)
+//     Example: bun scripts/fetch-mediawiki-doc.ts --raw https://commons.wikimedia.org "Module:Countries" "function"
+
+export {};
+
+const UA = 'Mozilla/5.0 (compatible; fetch-mediawiki-doc/1.0; User:DaxServer)';
+
+function extractSection(text: string, searchTerm: string): string {
+	const lines = text.split('\n');
+	const startIdx = lines.findIndex((l) => l.toLowerCase().includes(searchTerm.toLowerCase()));
+	if (startIdx === -1) {
+		console.error(`Term "${searchTerm}" not found`);
+		process.exit(1);
+	}
+	const headingMatch = lines[startIdx].match(/^(#{1,4})\s/);
+	const level = headingMatch ? headingMatch[1].length : 0;
+	const endIdx = lines.findIndex((l, i) => {
+		if (i <= startIdx) return false;
+		if (level === 0) return i > startIdx + 60;
+		const m = l.match(/^(#{1,4})\s/);
+		return m && m[1].length <= level;
+	});
+	return lines.slice(startIdx, endIdx === -1 ? startIdx + 80 : endIdx).join('\n');
+}
+
+async function fetchMarkdown(url: string, searchTerm?: string) {
+	const res = await fetch(`https://markdown.new/${url}`, {
+		headers: { 'User-Agent': UA, Accept: 'text/markdown, text/plain, */*' },
+	});
+	if (!res.ok) { console.error(`HTTP ${res.status}: ${res.statusText}`); process.exit(1); }
+	const text = await res.text();
+	if (!searchTerm) { process.stdout.write(text); return; }
+	console.log(extractSection(text, searchTerm));
+}
+
+async function fetchRaw(baseUrl: string, title: string, searchTerm?: string) {
+	const apiUrl = new URL('/w/api.php', baseUrl);
+	apiUrl.searchParams.set('action', 'query');
+	apiUrl.searchParams.set('titles', title);
+	apiUrl.searchParams.set('prop', 'revisions');
+	apiUrl.searchParams.set('rvprop', 'content');
+	apiUrl.searchParams.set('rvslots', 'main');
+	apiUrl.searchParams.set('format', 'json');
+	apiUrl.searchParams.set('formatversion', '2');
+
+	const res = await fetch(apiUrl.toString(), { headers: { 'User-Agent': UA } });
+	if (!res.ok) { console.error(`HTTP ${res.status}: ${res.statusText}`); process.exit(1); }
+
+	const data = await res.json();
+	const page = data.query.pages[0];
+	if (page.missing) { console.error(`Page "${title}" not found`); process.exit(1); }
+
+	const content: string = page.revisions[0].slots.main.content;
+	if (!searchTerm) { process.stdout.write(content); return; }
+	console.log(extractSection(content, searchTerm));
+}
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--raw') {
+	const [, baseUrl, title, searchTerm] = args;
+	if (!baseUrl || !title) {
+		console.error('Usage: fetch-mediawiki-doc.ts --raw <base-url> <Page:Title> [search-term]');
+		process.exit(1);
+	}
+	await fetchRaw(baseUrl, title, searchTerm);
+} else {
+	const [url, searchTerm] = args;
+	if (!url) {
+		console.error('Usage: fetch-mediawiki-doc.ts <wiki-url> [search-term]');
+		process.exit(1);
+	}
+	await fetchMarkdown(url, searchTerm);
+}

--- a/scripts/update-commons.ts
+++ b/scripts/update-commons.ts
@@ -29,7 +29,14 @@ interface EditResponse {
 }
 
 const API_BASE = 'https://commons.wikimedia.org/w/api.php';
-const PAGE_TITLE = 'User:DaxServer/new-category.js';
+
+const args = process.argv.slice(2);
+if (!args[0] || !args[1]) {
+  console.error('Usage: update-commons.ts <local-file> <wiki-page-title>');
+  process.exit(1);
+}
+const localFile: string = args[0];
+const pageTitle: string = args[1];
 
 // OAuth credentials from environment variables
 const credentials = {
@@ -123,15 +130,14 @@ async function main(): Promise<void> {
     const csrfToken = tokenResponse.query.tokens.csrftoken;
     console.log('CSRF token obtained');
 
-    // Read the new-category.js file content
-    const content: string = await Bun.file('new-category.js').text();
+    const content: string = await Bun.file(localFile).text();
 
     // Edit the page
     console.log('Updating page on Commons...');
     const editResponse: EditResponse = await apiPostRequest(
       {
         action: 'edit',
-        title: PAGE_TITLE,
+        title: pageTitle,
         format: 'json',
       },
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
Adds `newpp-report.js` — a userscript that reads `wgPageParseReport` (structured JS object) and renders parser limit metrics at the bottom of any page in a collapsible `<details>` block. Highlights rows where value exceeds limit in red.

Also generalizes `scripts/update-commons.ts` to accept `<local-file> <wiki-page-title>` as CLI args (was hardcoded to `new-category.js`), and updates the GitHub Actions workflow to deploy both `new-category.js` and `newpp-report.js` on push to main.