### PR TITLE
fix: move newpp report box to bottom of page content

### DIFF
--- a/newpp-report.js
+++ b/newpp-report.js
@@ -66,7 +66,7 @@ $.when(
 		</table>
 	</details>` );
 
-	$( '#content' ).append( $box );
+	$( '#bodyContent' ).append( $box );
 } );
 
 // </nowiki>


### PR DESCRIPTION
Appends to `#bodyContent` instead of `#content`. The Vector skin uses CSS grid on `#content`, so unpositioned children (no named grid area) auto-place into the first available cell — which renders above the page title. `#bodyContent` sits inside the named content grid area, so appending there puts the box at the bottom as intended.